### PR TITLE
Fix type of nodeTemplate prop to accept Function

### DIFF
--- a/src/treeview/treeview.component.tsx
+++ b/src/treeview/treeview.component.tsx
@@ -14,13 +14,13 @@ export interface TreeViewTypecast {
  */
 export class TreeViewComponent extends TreeView {
     public state: Readonly<{ children?: React.ReactNode | React.ReactNode[] }> 
-    & Readonly<TreeViewModel & DefaultHtmlAttributes& TreeViewTypecast>;
+    & Readonly<TreeViewModel & DefaultHtmlAttributes | TreeViewTypecast>;
     public setState: any;
     private getDefaultAttributes: Function;
     public initRenderCalled: boolean = false;
     private checkInjectedModules: boolean = true;
     public props: Readonly<{ children?: React.ReactNode | React.ReactNode[] }>
-     & Readonly<TreeViewModel & DefaultHtmlAttributes>;
+     & Readonly<TreeViewModel & DefaultHtmlAttributes | TreeViewTypecast>;
     public forceUpdate: (callBack?: () => any) => void;
     public context: Object;
     public isReactComponent: Object;


### PR DESCRIPTION
When trying to use React as the nodeTemplate of TreeView, we get a TS compiler error:

`Types of property 'nodeTemplate' are incompatible. Type '() => Element' is not assignable to type 'string'.`

example:
```tsx
const nodeTemplate = (props) => <Button>{props.text}</Button>;

export default class TreeTest extends React.Component {
  render() {
    return <TreeViewComponent  nodeTemplate={nodeTemplate} />;
  }
}
```
Screenshot
![image](https://user-images.githubusercontent.com/779615/41433355-a64818ea-6fe6-11e8-8808-510793968fb2.png)

The error happens in VS code (not in Stackblitz, because it doesn't validate types)
